### PR TITLE
updated syntax to be compatible with julia 0.4.6

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.3
+julia 0.4
 BinDeps
 @osx Homebrew
 MPI

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -50,4 +50,4 @@ provides(SimpleBuild,
              end)
           end), [libmumps_simple], os = :Unix)
 
-@BinDeps.install [:libmumps_simple => :libmumps_simple]
+@BinDeps.install Dict(:libmumps_simple => :libmumps_simple)

--- a/src/MUMPS.jl
+++ b/src/MUMPS.jl
@@ -27,8 +27,8 @@ type MUMPSException <: Exception
   msg :: ASCIIString
 end
 
-typealias MUMPSValueDataType Union(Float32, Float64, Complex64, Complex128);
-typealias MUMPSIntDataType   Union(Int64);
+typealias MUMPSValueDataType Union{Float32, Float64, Complex64, Complex128};
+typealias MUMPSIntDataType   Union{Int64};
 
 
 # See MUMPS User's Manual Section 5.1.
@@ -117,17 +117,17 @@ type Mumps{Tv <: MUMPSValueDataType}
   __id    :: Ptr{Void}         # Pointer to MUMPS struct. Do not touch.
   __sym   :: Int32             # Value of sym used by Mumps.
   icntl   :: Array{Int32,1}    # Integer control parameters.
-  cntl    :: Union(Array{Float32,1}, Array{Float64,1})    # Real control parameters.
+  cntl    :: Union{Array{Float32,1}, Array{Float64,1}}    # Real control parameters.
   n       :: Int32             # Order of the matrix factorized.
   infog   :: Array{Int32,1}
-  rinfog  :: Union(Array{Float32,1}, Array{Float64,1})
+  rinfog  :: Union{Array{Float32,1}, Array{Float64,1}}
   nnz     :: Int               # Number of nonzeros in factors.
-  det     :: FloatingPoint
+  det     :: AbstractFloat
   err     :: Int
 
   function Mumps(sym :: Int,
                  icntl :: Array{Int32,1},
-                 cntl  :: Union(Array{Float32,1}, Array{Float64,1}))
+                 cntl  :: Union{Array{Float32,1}, Array{Float64,1}})
 
     MPI.Initialized() || throw(MUMPSException("Initialize MPI first"));
 
@@ -158,7 +158,7 @@ type Mumps{Tv <: MUMPSValueDataType}
 
     infog = zeros(Int32, 40);
 
-    self = new(id, int32(sym), icntl, cntl, 0, infog, rinfog, 0, 0, 0);
+    self = new(id, Int32(sym), icntl, cntl, 0, infog, rinfog, 0, 0, 0);
     finalizer(self, finalize);  # Destructor.
     return self;
   end
@@ -184,7 +184,7 @@ end
 
 
 @doc "Terminate a Mumps instance." ->
-function finalize{Tv <: MUMPSValueDataType}(mumps :: Mumps{Tv})
+function Base.finalize{Tv <: MUMPSValueDataType}(mumps :: Mumps{Tv})
   if Tv == Float32
     @mumps_call(:mumps_finalize_float, Void, (Ptr{Void},), mumps.__id);
   elseif Tv == Float64
@@ -384,28 +384,28 @@ on the host only, and to retrieve it there.""" ->
 function get_solution{Tv <: MUMPSValueDataType}(mumps :: Mumps{Tv})
 
   if Tv == Float32
-    nrhs = int(@mumps_call(:mumps_get_nrhs_float, Int32, (Ptr{Void},), mumps.__id));
+    nrhs = Int(@mumps_call(:mumps_get_nrhs_float, Int32, (Ptr{Void},), mumps.__id));
 
     x = zeros(Float32, mumps.n * nrhs);
     @mumps_call(:mumps_get_solution_float, Void,
                 (Ptr{Void}, Ptr{Float32}),
                 mumps.__id,            x);
   elseif Tv == Float64
-    nrhs = int(@mumps_call(:mumps_get_nrhs_double, Int32, (Ptr{Void},), mumps.__id));
+    nrhs = Int(@mumps_call(:mumps_get_nrhs_double, Int32, (Ptr{Void},), mumps.__id));
 
     x = zeros(Float64, mumps.n * nrhs);
     @mumps_call(:mumps_get_solution_double, Void,
                 (Ptr{Void}, Ptr{Float64}),
                 mumps.__id,            x);
   elseif Tv == Complex64
-    nrhs = int(@mumps_call(:mumps_get_nrhs_float_complex, Int32, (Ptr{Void},), mumps.__id));
+    nrhs = Int(@mumps_call(:mumps_get_nrhs_float_complex, Int32, (Ptr{Void},), mumps.__id));
 
     x = zeros(Complex64, mumps.n * nrhs);
     @mumps_call(:mumps_get_solution_float_complex, Void,
                 (Ptr{Void}, Ptr{Complex64}),
                 mumps.__id,              x);
   else
-    nrhs = int(@mumps_call(:mumps_get_nrhs_double_complex, Int32, (Ptr{Void},), mumps.__id));
+    nrhs = Int(@mumps_call(:mumps_get_nrhs_double_complex, Int32, (Ptr{Void},), mumps.__id));
 
     x = zeros(Complex128, mumps.n * nrhs);
     @mumps_call(:mumps_get_solution_double_complex, Void,
@@ -413,7 +413,7 @@ function get_solution{Tv <: MUMPSValueDataType}(mumps :: Mumps{Tv})
                 mumps.__id,               x);
   end
 
-  return reshape(x, int(mumps.n), nrhs);
+  return reshape(x, Int(mumps.n), nrhs);
 end
 
 


### PR DESCRIPTION
and make all these warnings go away. Take a look if you want to pull this.